### PR TITLE
Syntax Design with ANTLR

### DIFF
--- a/language/src/main/java/fan/zhuyi/selfish/language/node/ContinuousExpressionNode.java
+++ b/language/src/main/java/fan/zhuyi/selfish/language/node/ContinuousExpressionNode.java
@@ -1,0 +1,11 @@
+package fan.zhuyi.selfish.language.node;
+
+import com.oracle.truffle.api.source.SourceSection;
+import fan.zhuyi.selfish.language.utils.SelfishProcess;
+
+
+public class ContinuousExpressionNode extends EvalExpressionNode {
+    public ContinuousExpressionNode(SourceSection section, ExpressionNode[] nodes, SelfishProcess.IOPipe[] pipes, boolean background) {
+        super(section, nodes, pipes, background);
+    }
+}

--- a/language/src/main/java/fan/zhuyi/selfish/language/node/ContinuousExpressionNode.java
+++ b/language/src/main/java/fan/zhuyi/selfish/language/node/ContinuousExpressionNode.java
@@ -5,7 +5,10 @@ import fan.zhuyi.selfish.language.utils.SelfishProcess;
 
 
 public class ContinuousExpressionNode extends EvalExpressionNode {
-    public ContinuousExpressionNode(SourceSection section, ExpressionNode[] nodes, SelfishProcess.IOPipe[] pipes, boolean background) {
+    private final boolean paralleled;
+
+    public ContinuousExpressionNode(SourceSection section, ExpressionNode[] nodes, SelfishProcess.IOPipe[] pipes, boolean background, boolean paralleled) {
         super(section, nodes, pipes, background);
+        this.paralleled = paralleled;
     }
 }

--- a/language/src/main/java/fan/zhuyi/selfish/language/node/EvalExpressionNode.java
+++ b/language/src/main/java/fan/zhuyi/selfish/language/node/EvalExpressionNode.java
@@ -1,0 +1,27 @@
+package fan.zhuyi.selfish.language.node;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.source.SourceSection;
+import fan.zhuyi.selfish.language.utils.SelfishProcess;
+
+public class EvalExpressionNode extends ExpressionNode {
+    @Children
+    protected final ExpressionNode[] nodes;
+
+    protected final SelfishProcess.IOPipe[] pipes;
+
+    protected final boolean background;
+
+    public EvalExpressionNode(SourceSection section, ExpressionNode[] nodes, SelfishProcess.IOPipe[] pipes, boolean background) {
+        super(section);
+        this.nodes = nodes;
+        this.pipes = pipes;
+        this.background = background;
+    }
+
+    @Override
+    public Object executeGeneric(VirtualFrame frame) {
+        /// TODO: implement this
+        return null;
+    }
+}

--- a/language/src/main/java/fan/zhuyi/selfish/language/node/ExpressionNode.java
+++ b/language/src/main/java/fan/zhuyi/selfish/language/node/ExpressionNode.java
@@ -6,11 +6,9 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
-import java.io.FileDescriptor;
 
 @TypeSystemReference(SelfishTypes.class)
 public abstract class ExpressionNode extends Node {
-
 
 
     SourceSection sourceSection;

--- a/language/src/main/java/fan/zhuyi/selfish/language/node/PipelinedExpressionNode.java
+++ b/language/src/main/java/fan/zhuyi/selfish/language/node/PipelinedExpressionNode.java
@@ -1,0 +1,9 @@
+package fan.zhuyi.selfish.language.node;
+
+import com.oracle.truffle.api.source.SourceSection;
+
+public class PipelinedExpressionNode extends EvalExpressionNode {
+    public PipelinedExpressionNode(SourceSection section, ExpressionNode[] nodes, boolean background) {
+        super(section, nodes, null, background);
+    }
+}


### PR DESCRIPTION
I am going to handle parsing the eval expressions.

Precedence:
- `<redirects>` 
- `|` pipeline
- `&&` continuous job
- '&' background marks, or parallel execution if used in `a & b` form

This follows from fish and bash.

Question:
~~We could also import something like a parallel pipeline?~~ 
Pipeline is already parallel according to bash.

I guess pipeline will be one of the hardest thing to implement later.
Basically, it mixes up our function and command.
What's worse, we want the pipeline to pass our language object.
I initially wanted to let command return a object containing some fields like
- stdout (pipe)
- stderr (pipe)
- return code

We may need think carefully of the semantic routine of all the mess.

Maybe we can consider something like Future and combine the things in an async environment
